### PR TITLE
Add new google plus app referrer to socials.

### DIFF
--- a/Socials.yml
+++ b/Socials.yml
@@ -65,6 +65,7 @@ Github:
 Google%2B:
   - plus.google.com
   - url.google.com
+  - com.google.android.apps.plus
 
 douban:
   - douban.com


### PR DESCRIPTION
Add referrer "com.google.android.apps.plus" of google plus mobile app to Socials.yml file.