### PR TITLE
Updated IxQuick and StartPage

### DIFF
--- a/SearchEngines.yml
+++ b/SearchEngines.yml
@@ -1903,6 +1903,7 @@ StartPage:
   -
     urls:
       - startpage.com
+      - classic.startpage.com
       - www.startpage.com
     params:
       - query

--- a/SearchEngines.yml
+++ b/SearchEngines.yml
@@ -1265,7 +1265,7 @@ Isodelen:
     params:
       - Keywords
     backlink: 'sokresultat?Keywords={k}'
-Ixquick:
+IxQuick:
   - 
     urls:
       - ixquick.com
@@ -1285,8 +1285,9 @@ Ixquick:
       - s5-eu4.ixquick.com
     params:
       - query
+    backlink: 'do/asearch?query={k}'
     hiddenkeyword:
-      - '/.*/'
+      - '/do/asearch'
 Jungle Key:
   - 
     urls:
@@ -1898,11 +1899,14 @@ Sputnik:
     params:
       - q
     backlink: 'search?q={k}'
-Startpage:
+StartPage:
   -
     urls:
       - startpage.com
-    params: []
+      - www.startpage.com
+    params:
+      - query
+    backlink: 'do/asearch?query={k}'
     hiddenkeyword:
       - '/do/asearch'
 Startpagina (Google):


### PR DESCRIPTION
Added backlinks to both, added params to StartPage.

StartPage is US branding, and IxQuick is their brand for therest of the world. They’re the same service and except for StartPage ranking US results higher.