### PR TITLE
Added com.google.android.googlequicksearchbox to Google

### DIFF
--- a/SearchEngines.yml
+++ b/SearchEngines.yml
@@ -831,6 +831,7 @@ Google:
       - 'gppgle.{}'
       - googel.com
       - 'googel.{}'
+      - com.google.android.googlequicksearchbox
       - search.avg.com
       - isearch.avg.com
     params:


### PR DESCRIPTION
The Google app on Android sends a referrer header of
"android-app://com.google.android.googlequicksearchbox".

Piwik already tracks this URI as normal URL, so it can be tracked under Google.