### PR TITLE
Added com.google.android.apps.plus to Google+

### DIFF
--- a/Socials.yml
+++ b/Socials.yml
@@ -65,6 +65,7 @@ Github:
 Google%2B:
   - plus.google.com
   - url.google.com
+  - com.google.android.apps.plus
 
 douban:
   - douban.com


### PR DESCRIPTION
The Google+ app on Android sends a referrer header of
"android-app://com.google.android.apps.plus".

Piwik already tracks this URI as normal URL, so it can be tracked under Google+.