### PR TITLE
Remove yahoo portal URLs from search engine list

### DIFF
--- a/SearchEngines.yml
+++ b/SearchEngines.yml
@@ -2229,12 +2229,10 @@ Yahoo!:
     urls:
       - search.yahoo.com
       - malaysia.search.yahoo.com
-      - yahoo.com
-      - 'yahoo.{}'
-      - '{}.yahoo.com'
+      - '{}.search.yahoo.com'
       - cade.yahoo.com
-      - espanol.yahoo.com
-      - qc.yahoo.com
+      - espanol.search.yahoo.com
+      - qc.search.yahoo.com
       - one.cn.yahoo.com
     params:
       - p


### PR DESCRIPTION
These URLs will never be used by Yahoo! for search engine referrals, but will be used for referrals from their news portal. Keeping these separate is important.