### PR TITLE
add Laban.vn search engine

### DIFF
--- a/SearchEngines.yml
+++ b/SearchEngines.yml
@@ -2469,3 +2469,10 @@ Zxuso:
     params:
       - search
     backlink: '#search={k}'
+Laban:
+  - 
+    urls:
+      - laban.vn
+    params:
+      - q
+backlink: 'search.html?q={k}'

--- a/SearchEngines.yml
+++ b/SearchEngines.yml
@@ -2475,4 +2475,4 @@ Laban:
       - laban.vn
     params:
       - q
-backlink: 'search.html?q={k}'
+    backlink: 'search.html?q={k}'


### PR DESCRIPTION
add the laban.vn (vietnam) search engine
referer example : http://laban.vn/search.html?q=192.681.1.1