### PR TITLE
Remove DMOZ

### DIFF
--- a/SearchEngines.yml
+++ b/SearchEngines.yml
@@ -553,13 +553,6 @@ DisconnectSearch:
     params: []
     hiddenkeyword:
       - '/.*/'
-dmoz:
-  - 
-    urls:
-      - dmoz.org
-      - editors.dmoz.org
-    params:
-      - search
 DuckDuckGo:
   - 
     urls:


### PR DESCRIPTION
DMOZ is closing March 14, 2017. No longer needed.

http://searchengineland.com/rip-dmoz-open-directory-project-closing-270291