### PR TITLE
Frinedster → Friendster

### DIFF
--- a/Socials.yml
+++ b/Socials.yml
@@ -38,7 +38,7 @@ Orkut:
 Myspace:
   - myspace.com
 
-Frinedster:
+Friendster:
   - friendster.com
 
 Badoo:


### PR DESCRIPTION
It's dead, but at least it won't be spelled wrong. :trollface: 