### PR TITLE
Add hiddenkeyword path regex for Yahoo! Japan

### DIFF
--- a/SearchEngines.yml
+++ b/SearchEngines.yml
@@ -2312,6 +2312,10 @@ Yahoo! Japan:
       - utf-8
       - euc-jp
       - ms932
+    hiddenkeyword:
+      - '/\/r\/.*/'
+      - '/^$/'
+      - '/'
   -
     urls:
       - jp.hao123.com


### PR DESCRIPTION
Without this, we fail to recognize modern Yahoo! Japan URLs.